### PR TITLE
Feature/cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,9 @@
 /tramp
 /url
 /projectile-bookmarks.eld
+/.org-id-locations
+/transient/
+/bookmarks
+/org-persist/
+/org-roam.db
+/projectile.cache

--- a/appearance.el
+++ b/appearance.el
@@ -1,0 +1,18 @@
+(setq modus-themes-bold-constructs t)
+(setq modus-themes-paren-match '(bold))
+(load-theme 'modus-vivendi t)
+
+(defun select-default-font ()
+  (let ((available-fonts (font-family-list))
+        (preferred-fonts '(("Hack" . "Hack-10")
+                           ("DejaVu Sans Mono" . "DejaVu Sans Mono-10")
+                           ("Liberation Mono" . "Liberation Mono-10")
+                           ("Menlo" . "Menlo-11")
+                           ("Consolas" . "Consolas-10"))))
+    (cdar (seq-filter (lambda (font)
+                        (member (car font) available-fonts))
+                      preferred-fonts))))
+
+(let ((the-font (select-default-font)))
+  (when the-font
+    (set-face-attribute 'default nil :font (select-default-font))))

--- a/cc.el
+++ b/cc.el
@@ -1,0 +1,193 @@
+;; A kludge that implements "Smart tabs" similarly to how it
+;; is done at http://www.emacswiki.org/SmartTabs
+;;
+;; Main difference is that this is easy to insert into a
+;; custom CC mode style.
+(defun muep-cpp-indent-hook ()
+  ;; Since this function will call c-indent-line which will
+  ;; cause this function to be called again, it has a
+  ;; mechanism to avoid recursing infinitely.
+  (if (not (boundp 'already-in-muep-cpp-indent-hook))
+      (progn
+        (save-excursion
+          ;; Remove existing whitespace from line beginning
+          (beginning-of-line)
+          (while (looking-at "\t*\\( +\\)\t+")
+            (replace-match "" nil nil nil 1))
+          (let (;; Mark that we are already in this...
+                (already-in-muep-cpp-indent-hook t)
+                ;; And set tab width to a high value
+                (tab-width fill-column)
+                (c-basic-offset fill-column))
+            ;; And perform re-indentation in that environment
+            (c-indent-line)))
+        ;; If point was left into the beginning of line, move
+        ;; forwards.
+        (while (looking-at "\\(\t\\| \\)")
+          (forward-char)))))
+
+;; This used in multiple styles, so spelled out one
+;; time here.
+(defconst muep-c-offsets-alist
+  '((innamespace . 0)))
+
+;; A customized C++ style. Likely needs some adjustment before being
+;; fully useful.
+(defconst muep-cpp-style
+  `("gnu"
+    (tab-width . 4)
+    (c-basic-offset . 4)
+    (cua-auto-tabify-rectangles . nil)
+    (c-special-indent-hook . muep-cpp-indent-hook)
+    (c-offsets-alist . ,muep-c-offsets-alist)
+    (indent-tabs-mode . t)))
+
+(c-add-style "muep" muep-cpp-style)
+
+;; A variant of the above that uses 4-space basic indentation instead
+;; of one tab. Nicely this does not need the special indent hook that
+;; is used in the "normal" muep style.
+(defconst muep-cpp-style-4spc
+  `("gnu"
+    (tab-width . 8)
+    (c-basic-offset . 4)
+    (c-offsets-alist . ,muep-c-offsets-alist)
+    (indent-tabs-mode . nil)))
+
+(c-add-style "muep4" muep-cpp-style-4spc)
+
+;; A simple "style" that disables the automatic indentation of emacs
+;; and sets some variables so that they suit editing a file that
+;; mostly uses tabs for indentation.
+(defconst manualtab-cpp-style
+  '("gnu"
+    (tab-width . 8)
+    (c-basic-offset . 8)
+    (c-syntactic-indentation . nil)
+    (indent-tabs-mode . t)))
+(c-add-style "manualtab" manualtab-cpp-style)
+
+;; A simple "style" that disables the automatic indentation of emacs
+;; and sets some variables so that they suit editing a file that
+;; mostly uses spaces for indentation.
+(defconst manualspc-cpp-style
+  '("gnu"
+    (tab-width . 8)
+    (c-basic-offset . 4)
+    (c-syntactic-indentation . nil)
+    (indent-tabs-mode . nil)))
+(c-add-style "manualspc" manualspc-cpp-style)
+
+(defun enable-ff-find-other-file ()
+  ;; Use C-c o to jump between headers and sources
+  (local-set-key (kbd "C-c o") 'ff-find-other-file))
+
+(defun muep-c-mode-keys ()
+    (define-key
+      c-mode-base-map
+      (kbd "<backtab>")
+      (lambda ()
+        (interactive)
+        (c-indent-line-or-region -1))))
+
+(add-hook 'c-initialization-hook 'muep-c-mode-keys)
+(add-hook 'c-mode-common-hook 'enable-ff-find-other-file)
+
+;; Seems I can not find anything similar in
+;; stock emacs, so let's roll our own
+(defun muep-any (predicate l)
+  (if
+      (consp l)
+      (if (funcall predicate (car l))
+          t
+        (muep-any predicate (cdr l)))
+    ;; Empty list does not have any
+    nil))
+
+;; Test if file name looks like a name of a C/C++ header
+(defun headerishp (fname)
+  (muep-any
+   (lambda (ext)
+     (equal (file-name-extension fname) ext))
+   '("h" "hh" "hpp")))
+
+;; Include guard generation
+(defun muep-get-include-guard-id ()
+  "Generate the include guard macro name based on current buffer filename."
+   (replace-regexp-in-string
+    "\\." "_"
+    (upcase (file-name-nondirectory (buffer-file-name)))))
+
+(defun muep-insert-include-guards ()
+  "Insert a C/C++ style include guard into the current buffer"
+  (interactive)
+  (insert
+   "#ifndef " (muep-get-include-guard-id) "\n"
+   "#define " (muep-get-include-guard-id) "\n\n\n"
+   "#endif\n"))
+
+;; Other boilerplate generation
+(defun muep-c-introheader ()
+  (let ((fname (file-relative-name (buffer-file-name)))
+        (datestr (format-time-string "%Y-%m-%d")))
+    (mapconcat 'identity
+               (list
+                "/*\n"
+                " * " fname "\n"
+                " *\n"
+                " * DESCRIBE THE PURPOSE OF THIS FILE HERE\n"
+                " */\n") "")))
+
+(defun muep-insert-c-boilerplate ()
+  "Insert common boilerplate into the current
+   file as a C comment"
+  (interactive)
+  (insert (muep-c-introheader))
+  (if (headerishp (file-name-nondirectory (buffer-file-name)))
+      (muep-insert-include-guards)))
+
+(defun muep-surround-region (start end)
+  "Insert a pair of strings so that they surround either point or
+   region, depending on if region is active"
+  (if (use-region-p)
+      (let ((orig-rb (region-beginning))
+            (orig-re (region-end)))
+          (goto-char orig-re)
+          (insert end)
+          (goto-char orig-rb)
+          (insert start)
+          (goto-char orig-rb)
+          (forward-line 1))
+      (let ((orig-pt (point)))
+        (insert start)
+        (insert "\n")
+        (insert end)
+        (goto-char orig-pt)
+        (forward-line 1))))
+
+(defun muep-cpp-namespace-text (name)
+  (let ((nsn (if (< 0 (length name)) (concat name " ") "")))
+    (mapconcat 'identity
+               (list
+                "namespace " nsn "{\n"
+                "\n"
+                "} /* namespace " nsn "*/")
+               "")))
+
+(defun muep-insert-cpp-namespace (name)
+  "Insert a C++ namespace block"
+  (interactive "Mname:")
+  (insert (muep-cpp-namespace-text name))
+  (forward-line -1))
+
+(defun muep-c-ifdef-start (name)
+  (mapconcat 'identity (list "#ifdef " name "\n") ""))
+
+(defun muep-c-ifdef-end (name)
+  (mapconcat 'identity (list "#endif /* defined " name " */\n") ""))
+
+(defun muep-insert-c-ifdef (name)
+  "Insert a C ifdef block"
+  (interactive "Mname:")
+  (muep-surround-region (muep-c-ifdef-start name)
+                        (muep-c-ifdef-end name)))

--- a/clojure.el
+++ b/clojure.el
@@ -1,0 +1,26 @@
+;; Clojure
+(add-hook 'clojure-mode-hook 'rainbow-delimiters-mode)
+(add-hook 'clojure-mode-hook #'paredit-mode)
+
+;; Cider
+(defun muep-cider-eval-and-test ()
+  (interactive)
+  (cider-eval-defun-at-point)
+  (cider-test-run-test))
+
+(defun muep-cider-eval-and-test-ns ()
+  (interactive)
+  (cider-load-buffer)
+  (cider-test-run-ns-tests nil))
+
+(defun muep-cider-keys ()
+  (define-key cider-mode-map (kbd "<f8> n") 'muep-cider-eval-and-test-ns)
+  (define-key cider-mode-map (kbd "<f8> t") 'muep-cider-eval-and-test))
+
+(add-hook 'cider-mode-hook 'muep-cider-keys)
+(add-hook 'cider-mode-hook 'rainbow-delimiters-mode)
+(add-hook 'cider-mode-hook #'paredit-mode)
+
+;; Cider REPL
+(add-hook 'cider-repl-mode-hook #'paredit-mode)
+(add-hook 'cider-repl-mode-hook 'rainbow-delimiters-mode)

--- a/early-init.el
+++ b/early-init.el
@@ -1,0 +1,5 @@
+;; Emacs bedrock starter kit suggests this for better startup time
+(setq gc-cons-threshold 10000000)
+
+(tool-bar-mode -1)
+(menu-bar-mode -1)

--- a/init.el
+++ b/init.el
@@ -151,21 +151,15 @@
   (set-face-attribute 'default nil :font (select-default-font))
 
   ;; Remove the toolbar from top of the X frames:
-  (if (fboundp 'tool-bar-mode)
-      (tool-bar-mode -1))
-  (if (fboundp 'menu-bar-mode)
-      (menu-bar-mode -1)))
-
  ;; On OS X the window system is called ns
  ((eq window-system 'ns)
   ;; Font selection
   (if (member "Menlo" (font-family-list))
       (set-face-attribute 'default nil :font "Menlo-11"))
 
-  ;; Avoid toolbar, but menubar is ok since the space is always used
-  ;; in OS X.
+  ;; In MacOS, is kind of makes sense to keep the menu bar
   (if (fboundp 'tool-bar-mode)
-      (tool-bar-mode -1))
+      (menu-bar-mode 1))
 
   ;; Modifier keys
   (setq mac-option-modifier nil
@@ -174,10 +168,6 @@
 
  ;; Windows specific tweaks
  ((eq window-system 'w32)
-  (if (fboundp 'tool-bar-mode)
-      (tool-bar-mode -1))
-  (if (fboundp 'menu-bar-mode)
-      (menu-bar-mode -1))
   (if (member "Consolas" (font-family-list))
       (set-face-attribute 'default nil :font "Consolas"))))
 

--- a/init.el
+++ b/init.el
@@ -8,17 +8,10 @@
 (setq custom-file "~/.emacs.d/custom.el")
 (load custom-file :noerror)
 
-(require 'package)
-
-;; Set us up to use a package repository.
-(when (< emacs-major-version 27)
-  (package-initialize))
-
-(add-to-list 'package-archives
-             '("melpa-stable" . "https://stable.melpa.org/packages/"))
-
-;; (add-to-list 'package-archives
-;;              '("melpa" . "https://melpa.org/packages/"))
+;; Set us up to use Melpa as the package repository. Emacs nowadays
+;; comes with some GNU-blessed package archives preconfigured, but it
+;; seems safer to stick with just one archive.
+(setq package-archives '(("melpa" . "https://melpa.org/packages/")))
 
 ;; A bunch of simple default overrides
 (column-number-mode 1)
@@ -34,46 +27,14 @@
   (if (file-directory-p default-directory)
       (normal-top-level-add-subdirs-to-load-path)))
 
+(load-file (expand-file-name "ivy.el" user-emacs-directory))
+(load-file (expand-file-name "magit.el" user-emacs-directory))
+(load-file (expand-file-name "org.el" user-emacs-directory))
+(load-file (expand-file-name "cc.el" user-emacs-directory))
+
 ;; Keybindings for things for which there seems to be no convenient
 ;; default.
-(global-set-key (kbd "C-x C-b") 'buffer-menu)
-(global-set-key (kbd "C-c d") 'delete-trailing-whitespace)
-(global-set-key (kbd "C-c f") 'describe-face)
 (global-set-key (kbd "M--") 'xref-find-references)
-(global-set-key "\C-cl" 'org-store-link)
-(global-set-key "\C-ca" 'org-agenda)
-(global-set-key "\C-cc" 'org-capture)
-(global-set-key "\C-cb" 'org-switchb)
-(if (functionp 'magit-status)
-    (global-set-key (kbd "C-x g") 'magit-status))
-
-(defun underscore-to-dash (txt)
-  (string-replace "_" "-" txt))
-
-(when (functionp 'org-roam-version)
-  (require 'org)
-  (require 'org-roam)
-  (require 'org-roam-dailies)
-  ;; Keybinding suggestions from
-  ;; https://lucidmanager.org/productivity/taking-notes-with-emacs-org-mode-and-org-roam/
-  (global-set-key (kbd "C-c n f") 'org-roam-node-find)
-  (global-set-key (kbd "C-c n r") 'org-roam-node-random)
-  (global-set-key (kbd "C-c n d") 'org-roam-dailies-map)
-  (define-key org-mode-map (kbd "C-c n i") 'org-roam-node-insert)
-  (define-key org-mode-map (kbd "C-c n o") 'org-id-get-create)
-  (define-key org-mode-map (kbd "C-c n t") 'org-roam-tag-add)
-  (define-key org-mode-map (kbd "C-c n a") 'org-roam-alias-add)
-  (define-key org-mode-map (kbd "C-c n l") 'org-roam-buffer-toggle)
-
-  (advice-add 'org-roam-node-slug :filter-return #'underscore-to-dash)
-
-  (setq org-roam-capture-templates
-        '(("d" "default" plain "%?" :target
-           (file+head "${slug}.org"
-                      "#+title: ${title}\n")
-           :unnarrowed t)))
-  (setq org-roam-directory (file-truename "~/org/zk"))
-  (org-roam-db-autosync-mode))
 
 ;; Clojure
 (add-hook 'clojure-mode-hook 'rainbow-delimiters-mode)
@@ -142,9 +103,8 @@
  ;; Mostly just GNU/Linux
  ((eq window-system 'x)
   ;; Font selection
-  (set-face-attribute 'default nil :font (select-default-font))
+  (set-face-attribute 'default nil :font (select-default-font)))
 
-  ;; Remove the toolbar from top of the X frames:
  ;; On OS X the window system is called ns
  ((eq window-system 'ns)
   ;; Font selection
@@ -179,226 +139,19 @@
       (add-hook 'lisp-interaction-mode-hook #'rainbow-delimiters-mode)
       (add-hook 'scheme-mode-hook           #'rainbow-delimiters-mode)))
 
-(when (functionp 'projectile-mode)
-    (projectile-mode +1)
-    (define-key projectile-mode-map (kbd "C-c p") 'projectile-command-map)
-    (when (functionp 'counsel-projectile-mode)
-      (counsel-projectile-mode)
-      ;; This overrides the stock buffer change command
-      (global-set-key (kbd "C-x C-b") 'counsel-switch-buffer)))
-
 (require 'uniquify)
 (setq uniquify-buffer-name-style 'post-forward
       uniquify-separator ":")
 
-;; A kludge that implements "Smart tabs" similarly to how it
-;; is done at http://www.emacswiki.org/SmartTabs
-;;
-;; Main difference is that this is easy to insert into a
-;; custom CC mode style.
-(defun muep-cpp-indent-hook ()
-  ;; Since this function will call c-indent-line which will
-  ;; cause this function to be called again, it has a
-  ;; mechanism to avoid recursing infinitely.
-  (if (not (boundp 'already-in-muep-cpp-indent-hook))
-      (progn
-        (save-excursion
-          ;; Remove existing whitespace from line beginning
-          (beginning-of-line)
-          (while (looking-at "\t*\\( +\\)\t+")
-            (replace-match "" nil nil nil 1))
-          (let (;; Mark that we are already in this...
-                (already-in-muep-cpp-indent-hook t)
-                ;; And set tab width to a high value
-                (tab-width fill-column)
-                (c-basic-offset fill-column))
-            ;; And perform re-indentation in that environment
-            (c-indent-line)))
-        ;; If point was left into the beginning of line, move
-        ;; forwards.
-        (while (looking-at "\\(\t\\| \\)")
-          (forward-char)))))
-
-;; This used in multiple styles, so spelled out one
-;; time here.
-(defconst muep-c-offsets-alist
-  '((innamespace . 0)))
-
-;; A customized C++ style. Likely needs some adjustment before being
-;; fully useful.
-(defconst muep-cpp-style
-  `("gnu"
-    (tab-width . 4)
-    (c-basic-offset . 4)
-    (cua-auto-tabify-rectangles . nil)
-    (c-special-indent-hook . muep-cpp-indent-hook)
-    (c-offsets-alist . ,muep-c-offsets-alist)
-    (indent-tabs-mode . t)))
-
-(c-add-style "muep" muep-cpp-style)
-
-;; A variant of the above that uses 4-space basic indentation instead
-;; of one tab. Nicely this does not need the special indent hook that
-;; is used in the "normal" muep style.
-(defconst muep-cpp-style-4spc
-  `("gnu"
-    (tab-width . 8)
-    (c-basic-offset . 4)
-    (c-offsets-alist . ,muep-c-offsets-alist)
-    (indent-tabs-mode . nil)))
-
-(c-add-style "muep4" muep-cpp-style-4spc)
-
-;; A simple "style" that disables the automatic indentation of emacs
-;; and sets some variables so that they suit editing a file that
-;; mostly uses tabs for indentation.
-(defconst manualtab-cpp-style
-  '("gnu"
-    (tab-width . 8)
-    (c-basic-offset . 8)
-    (c-syntactic-indentation . nil)
-    (indent-tabs-mode . t)))
-(c-add-style "manualtab" manualtab-cpp-style)
-
-;; A simple "style" that disables the automatic indentation of emacs
-;; and sets some variables so that they suit editing a file that
-;; mostly uses spaces for indentation.
-(defconst manualspc-cpp-style
-  '("gnu"
-    (tab-width . 8)
-    (c-basic-offset . 4)
-    (c-syntactic-indentation . nil)
-    (indent-tabs-mode . nil)))
-(c-add-style "manualspc" manualspc-cpp-style)
-
-(defun enable-ff-find-other-file ()
-  ;; Use C-c o to jump between headers and sources
-  (local-set-key (kbd "C-c o") 'ff-find-other-file))
 
 (defun enable-autoclear-whitespace ()
   (add-hook 'before-save-hook 'delete-trailing-whitespace nil t))
-
-(defun muep-c-mode-keys ()
-    (define-key
-      c-mode-base-map
-      (kbd "<backtab>")
-      (lambda ()
-        (interactive)
-        (c-indent-line-or-region -1))))
-
-(add-hook 'c-initialization-hook 'muep-c-mode-keys)
-(add-hook 'c-mode-common-hook 'enable-ff-find-other-file)
-
-;; Nicer auto fill for org mode
-(add-hook 'org-mode-hook
-          (lambda ()
-            (auto-fill-mode t)
-            (setq fill-column 60)))
 
 ;; Enable a bunch of functions that are disabled by default to avoid
 ;; confusion.
 (put 'downcase-region 'disabled nil)
 (put 'narrow-to-region 'disabled nil)
 (put 'upcase-region 'disabled nil)
-
-;; Seems I can not find anything similar in
-;; stock emacs, so let's roll our own
-(defun muep-any (predicate l)
-  (if
-      (consp l)
-      (if (funcall predicate (car l))
-          t
-        (muep-any predicate (cdr l)))
-    ;; Empty list does not have any
-    nil))
-
-;; Test if file name looks like a name of a C/C++ header
-(defun headerishp (fname)
-  (muep-any
-   (lambda (ext)
-     (equal (file-name-extension fname) ext))
-   '("h" "hh" "hpp")))
-
-;; Include guard generation
-(defun muep-get-include-guard-id ()
-  "Generate the include guard macro name based on current buffer filename."
-   (replace-regexp-in-string
-    "\\." "_"
-    (upcase (file-name-nondirectory (buffer-file-name)))))
-
-(defun muep-insert-include-guards ()
-  "Insert a C/C++ style include guard into the current buffer"
-  (interactive)
-  (insert
-   "#ifndef " (muep-get-include-guard-id) "\n"
-   "#define " (muep-get-include-guard-id) "\n\n\n"
-   "#endif\n"))
-
-;; Other boilerplate generation
-(defun muep-c-introheader ()
-  (let ((fname (file-relative-name (buffer-file-name)))
-        (datestr (format-time-string "%Y-%m-%d")))
-    (mapconcat 'identity
-               (list
-                "/*\n"
-                " * " fname "\n"
-                " *\n"
-                " * DESCRIBE THE PURPOSE OF THIS FILE HERE\n"
-                " */\n") "")))
-
-(defun muep-insert-c-boilerplate ()
-  "Insert common boilerplate into the current
-   file as a C comment"
-  (interactive)
-  (insert (muep-c-introheader))
-  (if (headerishp (file-name-nondirectory (buffer-file-name)))
-      (muep-insert-include-guards)))
-
-(defun muep-surround-region (start end)
-  "Insert a pair of strings so that they surround either point or
-   region, depending on if region is active"
-  (if (use-region-p)
-      (let ((orig-rb (region-beginning))
-            (orig-re (region-end)))
-          (goto-char orig-re)
-          (insert end)
-          (goto-char orig-rb)
-          (insert start)
-          (goto-char orig-rb)
-          (forward-line 1))
-      (let ((orig-pt (point)))
-        (insert start)
-        (insert "\n")
-        (insert end)
-        (goto-char orig-pt)
-        (forward-line 1))))
-
-(defun muep-cpp-namespace-text (name)
-  (let ((nsn (if (< 0 (length name)) (concat name " ") "")))
-    (mapconcat 'identity
-               (list
-                "namespace " nsn "{\n"
-                "\n"
-                "} /* namespace " nsn "*/")
-               "")))
-
-(defun muep-insert-cpp-namespace (name)
-  "Insert a C++ namespace block"
-  (interactive "Mname:")
-  (insert (muep-cpp-namespace-text name))
-  (forward-line -1))
-
-(defun muep-c-ifdef-start (name)
-  (mapconcat 'identity (list "#ifdef " name "\n") ""))
-
-(defun muep-c-ifdef-end (name)
-  (mapconcat 'identity (list "#endif /* defined " name " */\n") ""))
-
-(defun muep-insert-c-ifdef (name)
-  "Insert a C ifdef block"
-  (interactive "Mname:")
-  (muep-surround-region (muep-c-ifdef-start name)
-                        (muep-c-ifdef-end name)))
 
 (defun muep-py2-boilerplate ()
   "Insert a group of future imports for Python 2"

--- a/init.el
+++ b/init.el
@@ -19,201 +19,36 @@
 (setq-default indent-tabs-mode nil)
 (setq inhibit-startup-screen t)
 (setq make-backup-files nil)
-(setq-default show-trailing-whitespace t)
 (electric-indent-mode -1)
 
-;; Add a convenient place for some local lisp code, if any
-(let ((default-directory  "~/.emacs.d/lisp/"))
-  (if (file-directory-p default-directory)
-      (normal-top-level-add-subdirs-to-load-path)))
+(when window-system
+  ;; Let's avoid touching it when in terminal
+  (load-file (expand-file-name "appearance.el" user-emacs-directory)))
 
 (load-file (expand-file-name "ivy.el" user-emacs-directory))
 (load-file (expand-file-name "magit.el" user-emacs-directory))
 (load-file (expand-file-name "org.el" user-emacs-directory))
-(load-file (expand-file-name "cc.el" user-emacs-directory))
+(load-file (expand-file-name "lisps.el" user-emacs-directory))
+; (load-file (expand-file-name "cc.el" user-emacs-directory))
+; (load-file (expand-file-name "clojure.el" user-emacs-directory))
+; (load-file (expand-file-name "trailing-whitespace.el" user-emacs-directory))
 
 ;; Keybindings for things for which there seems to be no convenient
 ;; default.
 (global-set-key (kbd "M--") 'xref-find-references)
 
-;; Clojure
-(add-hook 'clojure-mode-hook 'rainbow-delimiters-mode)
-(add-hook 'clojure-mode-hook #'paredit-mode)
-
-;; Cider
-(defun muep-cider-eval-and-test ()
-  (interactive)
-  (cider-eval-defun-at-point)
-  (cider-test-run-test))
-
-(defun muep-cider-eval-and-test-ns ()
-  (interactive)
-  (cider-load-buffer)
-  (cider-test-run-ns-tests nil))
-
-(defun muep-cider-keys ()
-  (define-key cider-mode-map (kbd "<f8> n") 'muep-cider-eval-and-test-ns)
-  (define-key cider-mode-map (kbd "<f8> t") 'muep-cider-eval-and-test))
-
-(add-hook 'cider-mode-hook 'muep-cider-keys)
-(add-hook 'cider-mode-hook 'rainbow-delimiters-mode)
-(add-hook 'cider-mode-hook #'paredit-mode)
-
-;; Cider REPL
-(add-hook 'cider-repl-mode-hook #'paredit-mode)
-(add-hook 'cider-repl-mode-hook 'rainbow-delimiters-mode)
-
-(defun disable-trailing-whitespace-display ()
-  (setq show-trailing-whitespace nil))
-
-;; Disable trailing whitespace display for special-mode children. This
-;; includes stuff like the git log view mode and suchlike.
-(add-hook 'special-mode-hook 'disable-trailing-whitespace-display)
-
-;; Also some others
-(add-hook 'compilation-mode-hook 'disable-trailing-whitespace-display)
-(add-hook 'diff-mode-hook 'disable-trailing-whitespace-display)
-(add-hook 'term-mode-hook 'disable-trailing-whitespace-display)
-(add-hook 'shell-mode-hook 'disable-trailing-whitespace-display)
-
-(defun setup-theme ()
-  (setq modus-themes-bold-constructs t)
-  (setq modus-themes-paren-match '(bold))
-  (load-theme 'modus-vivendi t))
-
-(if window-system
-    (progn
-      ;; Initialization for cases when we are in some window system
-      (setup-theme)
-      (windmove-default-keybindings))
-  ;; Could add items that are only required in terminal mode.
-  )
-
-(defun select-default-font ()
-  (let ((available-fonts (font-family-list))
-        (preferred-fonts '(("Hack" . "Hack-10")
-                           ("DejaVu Sans Mono" . "DejaVu Sans Mono-10")
-                           ("Liberation Mono" . "Liberation Mono-10"))))
-    (cdar (seq-filter (lambda (font)
-                        (member (car font) available-fonts))
-                      preferred-fonts))))
-
 ;; Platform specific tweaks
 (cond
- ;; Mostly just GNU/Linux
- ((eq window-system 'x)
-  ;; Font selection
-  (set-face-attribute 'default nil :font (select-default-font)))
-
  ;; On OS X the window system is called ns
  ((eq window-system 'ns)
-  ;; Font selection
-  (if (member "Menlo" (font-family-list))
-      (set-face-attribute 'default nil :font "Menlo-11"))
-
-  ;; In MacOS, is kind of makes sense to keep the menu bar
-  (if (fboundp 'tool-bar-mode)
-      (menu-bar-mode 1))
-
-  ;; Modifier keys
-  (setq mac-option-modifier nil
-        mac-command-modifier 'meta
-        x-select-enable-clipboard t))
+  (load-file (expand-file-name "macos.el" user-emacs-directory)))
 
  ;; Windows specific tweaks
  ((eq window-system 'w32)
-  (if (member "Consolas" (font-family-list))
-      (set-face-attribute 'default nil :font "Consolas"))))
-
-;; Install paredit from MELPA to make use of this
-(if (functionp 'enable-paredit-mode)
-    (progn
-      (add-hook 'emacs-lisp-mode-hook       #'enable-paredit-mode)
-      (add-hook 'lisp-interaction-mode-hook #'enable-paredit-mode)
-      (add-hook 'scheme-mode-hook           #'enable-paredit-mode)))
-
-;; Install rainbow-delimiters from MELPA to make use of this
-(if (functionp 'rainbow-delimiters-mode)
-    (progn
-      (add-hook 'emacs-lisp-mode-hook       #'rainbow-delimiters-mode)
-      (add-hook 'lisp-interaction-mode-hook #'rainbow-delimiters-mode)
-      (add-hook 'scheme-mode-hook           #'rainbow-delimiters-mode)))
-
-(require 'uniquify)
-(setq uniquify-buffer-name-style 'post-forward
-      uniquify-separator ":")
-
-
-(defun enable-autoclear-whitespace ()
-  (add-hook 'before-save-hook 'delete-trailing-whitespace nil t))
+  (load-file (expand-file-name "windows.el" user-emacs-directory))))
 
 ;; Enable a bunch of functions that are disabled by default to avoid
 ;; confusion.
 (put 'downcase-region 'disabled nil)
 (put 'narrow-to-region 'disabled nil)
 (put 'upcase-region 'disabled nil)
-
-(defun muep-py2-boilerplate ()
-  "Insert a group of future imports for Python 2"
-  (interactive)
-  (insert
-   (mapconcat
-    'identity
-    '("from __future__ import absolute_import\n"
-      "from __future__ import division\n"
-      "from __future__ import print_function\n"
-      "from __future__ import unicode_literals\n")
-    "")))
-
-(defun muep-string-trim-left (s)
-  (replace-regexp-in-string "^[\s\t\n]" "" s))
-
-(defun muep-string-trim-right (s)
-  (replace-regexp-in-string "[\s\t\n]$" "" s))
-
-;; No idea why stuff like this does not seem to be built-in
-(defun muep-string-trim (s)
-  (muep-string-trim-left (muep-string-trim-right s)))
-
-(defun muep-insert-specfile-date ()
-  "Insert date as expected in Fedora changelogs"
-  (interactive)
-  (insert
-   (muep-string-trim
-    (shell-command-to-string "env LC_ALL=C date \"+%a %b %d %Y\""))))
-
-(defun muep-insert-reldate (n)
-  "Insert a date relative to today"
-  (interactive "Noffset:")
-  (let* ((now (current-time))
-         (dif (days-to-time n))
-         (then (time-add now dif)))
-    (insert
-     (format-time-string "%Y-%m-%d" then))))
-
-(defun muep-insert-today ()
-  "Insert the date of today"
-  (interactive)
-  (muep-insert-reldate 0))
-
-(defun buffer-line-count ()
-  "Return the number of lines in this buffer."
-  (count-lines (point-min) (point-max)))
-
-(defun goto-random-line ()
-  "Go to a random line in this buffer."
-  ; good for electrobibliomancy.
-  (interactive)
-  (goto-line (1+ (random (buffer-line-count)))))
-
-;; From https://emacsredux.com/blog/2013/06/21/eval-and-replace/
-(defun eval-and-replace ()
-  "Replace the preceding sexp with its value."
-  (interactive)
-  (backward-kill-sexp)
-  (condition-case nil
-      (prin1 (eval (read (current-kill 0)))
-             (current-buffer))
-    (error (message "Invalid expression")
-           (insert (current-kill 0)))))
-(global-set-key (kbd "C-c e") 'eval-and-replace)

--- a/init.el
+++ b/init.el
@@ -3,12 +3,6 @@
 ;; Personal emacs configuration for Joonas Sarajärvi
 ;; See README for more information.
 
-(when (version< emacs-version "26.3")
-  ;; Seems to be required on older versions of Emacs. See
-  ;; https://debbugs.gnu.org/cgi/bugreport.cgi?bug=34341
-  ;; https://debbugs.gnu.org/cgi/bugreport.cgi?bug=36725
-  (setq gnutls-algorithm-priority "NORMAL:-VERS-TLS1.3"))
-
 ;; Load the Customize data from elsewhere, to avoid making them change
 ;; this init file.
 (setq custom-file "~/.emacs.d/custom.el")

--- a/init.el
+++ b/init.el
@@ -8,10 +8,11 @@
 (setq custom-file "~/.emacs.d/custom.el")
 (load custom-file :noerror)
 
-;; Set us up to use Melpa as the package repository. Emacs nowadays
-;; comes with some GNU-blessed package archives preconfigured, but it
-;; seems safer to stick with just one archive.
-(setq package-archives '(("melpa" . "https://melpa.org/packages/")))
+;; Set us up to use Melpa as the package repository. At least some
+;; packages expect the GNU archive to be in use, so that is included
+;; as well.
+(setq package-archives '(("melpa" . "https://melpa.org/packages/")
+                         ("gnu" . "https://elpa.gnu.org/packages/")))
 
 ;; A bunch of simple default overrides
 (column-number-mode 1)

--- a/ivy.el
+++ b/ivy.el
@@ -1,3 +1,7 @@
+; (require 'uniquify)
+; (setq uniquify-buffer-name-style 'post-forward
+;       uniquify-separator ":")
+
 (use-package projectile
   :ensure t
   :bind-keymap ("C-c p" . projectile-command-map)

--- a/ivy.el
+++ b/ivy.el
@@ -1,15 +1,15 @@
 ; (require 'uniquify)
 ; (setq uniquify-buffer-name-style 'post-forward
 ;       uniquify-separator ":")
+(use-package diminish
+  :ensure t)
 
 (use-package projectile
+  :diminish
   :ensure t
   :bind-keymap ("C-c p" . projectile-command-map)
   :config
   (projectile-mode +1))
-
-(use-package diminish
-  :ensure t)
 
 (use-package ivy
   :diminish

--- a/ivy.el
+++ b/ivy.el
@@ -1,0 +1,14 @@
+(use-package projectile
+  :ensure t
+  :bind-keymap ("C-c p" . projectile-command-map)
+  :config
+  (projectile-mode +1))
+
+(use-package diminish
+  :ensure t)
+
+(use-package ivy
+  :diminish
+  :ensure t
+  :config
+  (ivy-mode 1))

--- a/lisps.el
+++ b/lisps.el
@@ -1,0 +1,11 @@
+(use-package paredit
+  :ensure t
+  :hook ((emacs-lisp-mode . enable-paredit-mode)
+         (lisp-interaction-mode . enable-paredit-mode)
+         (scheme-mode . enable-paredit-mode)))
+
+(use-package rainbow-delimiters
+  :ensure t
+  :hook ((emacs-lisp-mode . rainbow-delimiters-mode)
+         (lisp-interaction-mode . rainbow-delimiters-mode)
+         (scheme-mode . rainbow-delimiters-mode)))

--- a/lisps.el
+++ b/lisps.el
@@ -1,4 +1,5 @@
 (use-package paredit
+  :diminish
   :ensure t
   :hook ((emacs-lisp-mode . enable-paredit-mode)
          (lisp-interaction-mode . enable-paredit-mode)

--- a/macos.el
+++ b/macos.el
@@ -1,0 +1,8 @@
+;; In MacOS, is kind of makes sense to keep the menu bar
+(if (fboundp 'tool-bar-mode)
+    (menu-bar-mode 1))
+
+;; Modifier keys
+(setq mac-option-modifier nil
+      mac-command-modifier 'meta
+      x-select-enable-clipboard t)

--- a/magit.el
+++ b/magit.el
@@ -1,0 +1,4 @@
+(use-package magit
+  :ensure t
+  :defer
+  :bind (("C-x g" . magit-status)))

--- a/org.el
+++ b/org.el
@@ -1,43 +1,37 @@
-(use-package org)
-(use-package org-roam
-  :ensure t)
-
-(global-set-key "\C-cl" 'org-store-link)
-(global-set-key "\C-ca" 'org-agenda)
-(global-set-key "\C-cc" 'org-capture)
-(global-set-key "\C-cb" 'org-switchb)
+;; Same as current org default, but maybe better be explicit
+(setq org-directory "~/org")
+(setq org-agenda-files '("inbox.org" "work.org"))
+(setq org-roam-directory (file-truename "~/org/zk"))
 
 (defun underscore-to-dash (txt)
   (string-replace "_" "-" txt))
 
-(when (functionp 'org-roam-version)
-  (require 'org)
-  (require 'org-roam)
-  (require 'org-roam-dailies)
-  ;; Keybinding suggestions from
-  ;; https://lucidmanager.org/productivity/taking-notes-with-emacs-org-mode-and-org-roam/
-  (global-set-key (kbd "C-c n f") 'org-roam-node-find)
-  (global-set-key (kbd "C-c n r") 'org-roam-node-random)
-  (global-set-key (kbd "C-c n d") 'org-roam-dailies-map)
-  (define-key org-mode-map (kbd "C-c n i") 'org-roam-node-insert)
-  (define-key org-mode-map (kbd "C-c n o") 'org-id-get-create)
-  (define-key org-mode-map (kbd "C-c n t") 'org-roam-tag-add)
-  (define-key org-mode-map (kbd "C-c n a") 'org-roam-alias-add)
-  (define-key org-mode-map (kbd "C-c n l") 'org-roam-buffer-toggle)
-
+(use-package org
+  :defer t
+  :bind (:map global-map
+              ("C-c a" . org-agenda))
+  )
+(use-package org-roam
+  :defer t
+  :ensure t
+  :bind
+  (("C-c n f" . org-roam-node-find)
+   ("C-c n r" . org-roam-node-random)
+   :map org-mode-map
+   ("C-c n i" . org-roam-node-insert)
+   ("C-c n o" . org-id-get-create)
+   ("C-c n t" . org-roam-tag-add)
+   ("C-c n a" . org-roam-alias-add)
+   ("C-c n l" . org-roam-buffer-toggle))
+  :config 
   (advice-add 'org-roam-node-slug :filter-return #'underscore-to-dash)
-
   (setq org-roam-capture-templates
         '(("d" "default" plain "%?" :target
            (file+head "${slug}.org"
                       "#+title: ${title}\n")
            :unnarrowed t)))
-  (setq org-roam-directory (file-truename "~/org/zk"))
   (org-roam-db-autosync-mode))
 
-;; Nicer auto fill for org mode
-(add-hook 'org-mode-hook
-          (lambda ()
-            (auto-fill-mode t)
-            (setq fill-column 60)))
-
+(use-package org-roam-dailies
+  :defer t
+  :bind (("C-c n d" . org-roam-dailies-map)))

--- a/org.el
+++ b/org.el
@@ -1,8 +1,6 @@
 ;; Same as current org default, but maybe better be explicit
 (setq org-directory "~/org")
-(setq org-agenda-files '("agenda/inbox.org"
-                         "agenda/code.org"
-                         "agenda/done.org"))
+(setq org-agenda-files '("~/org/agenda"))
 
 (setq org-roam-directory (file-truename "~/org/zk"))
 

--- a/org.el
+++ b/org.el
@@ -37,4 +37,4 @@
 
 (use-package org-roam-dailies
   :defer t
-  :bind (("C-c n d" . org-roam-dailies-map)))
+  :bind-keymap (("C-c n d" . org-roam-dailies-map)))

--- a/org.el
+++ b/org.el
@@ -1,6 +1,9 @@
 ;; Same as current org default, but maybe better be explicit
 (setq org-directory "~/org")
-(setq org-agenda-files '("inbox.org" "work.org"))
+(setq org-agenda-files '("agenda/inbox.org"
+                         "agenda/code.org"
+                         "agenda/done.org"))
+
 (setq org-roam-directory (file-truename "~/org/zk"))
 
 (defun underscore-to-dash (txt)

--- a/org.el
+++ b/org.el
@@ -1,0 +1,43 @@
+(use-package org)
+(use-package org-roam
+  :ensure t)
+
+(global-set-key "\C-cl" 'org-store-link)
+(global-set-key "\C-ca" 'org-agenda)
+(global-set-key "\C-cc" 'org-capture)
+(global-set-key "\C-cb" 'org-switchb)
+
+(defun underscore-to-dash (txt)
+  (string-replace "_" "-" txt))
+
+(when (functionp 'org-roam-version)
+  (require 'org)
+  (require 'org-roam)
+  (require 'org-roam-dailies)
+  ;; Keybinding suggestions from
+  ;; https://lucidmanager.org/productivity/taking-notes-with-emacs-org-mode-and-org-roam/
+  (global-set-key (kbd "C-c n f") 'org-roam-node-find)
+  (global-set-key (kbd "C-c n r") 'org-roam-node-random)
+  (global-set-key (kbd "C-c n d") 'org-roam-dailies-map)
+  (define-key org-mode-map (kbd "C-c n i") 'org-roam-node-insert)
+  (define-key org-mode-map (kbd "C-c n o") 'org-id-get-create)
+  (define-key org-mode-map (kbd "C-c n t") 'org-roam-tag-add)
+  (define-key org-mode-map (kbd "C-c n a") 'org-roam-alias-add)
+  (define-key org-mode-map (kbd "C-c n l") 'org-roam-buffer-toggle)
+
+  (advice-add 'org-roam-node-slug :filter-return #'underscore-to-dash)
+
+  (setq org-roam-capture-templates
+        '(("d" "default" plain "%?" :target
+           (file+head "${slug}.org"
+                      "#+title: ${title}\n")
+           :unnarrowed t)))
+  (setq org-roam-directory (file-truename "~/org/zk"))
+  (org-roam-db-autosync-mode))
+
+;; Nicer auto fill for org mode
+(add-hook 'org-mode-hook
+          (lambda ()
+            (auto-fill-mode t)
+            (setq fill-column 60)))
+

--- a/random-utils.el
+++ b/random-utils.el
@@ -1,0 +1,66 @@
+;; Code kept over from past config, but cleaned here since it's not
+;; clear if I actually need this
+(defun muep-py2-boilerplate ()
+  "Insert a group of future imports for Python 2"
+  (interactive)
+  (insert
+   (mapconcat
+    'identity
+    '("from __future__ import absolute_import\n"
+      "from __future__ import division\n"
+      "from __future__ import print_function\n"
+      "from __future__ import unicode_literals\n")
+    "")))
+
+(defun muep-string-trim-left (s)
+  (replace-regexp-in-string "^[\s\t\n]" "" s))
+
+(defun muep-string-trim-right (s)
+  (replace-regexp-in-string "[\s\t\n]$" "" s))
+
+;; No idea why stuff like this does not seem to be built-in
+(defun muep-string-trim (s)
+  (muep-string-trim-left (muep-string-trim-right s)))
+
+(defun muep-insert-specfile-date ()
+  "Insert date as expected in Fedora changelogs"
+  (interactive)
+  (insert
+   (muep-string-trim
+    (shell-command-to-string "env LC_ALL=C date \"+%a %b %d %Y\""))))
+
+(defun muep-insert-reldate (n)
+  "Insert a date relative to today"
+  (interactive "Noffset:")
+  (let* ((now (current-time))
+         (dif (days-to-time n))
+         (then (time-add now dif)))
+    (insert
+     (format-time-string "%Y-%m-%d" then))))
+
+(defun muep-insert-today ()
+  "Insert the date of today"
+  (interactive)
+  (muep-insert-reldate 0))
+
+(defun buffer-line-count ()
+  "Return the number of lines in this buffer."
+  (count-lines (point-min) (point-max)))
+
+(defun goto-random-line ()
+  "Go to a random line in this buffer."
+  ; good for electrobibliomancy.
+  (interactive)
+  (goto-line (1+ (random (buffer-line-count)))))
+
+;; From https://emacsredux.com/blog/2013/06/21/eval-and-replace/
+(defun eval-and-replace ()
+  "Replace the preceding sexp with its value."
+  (interactive)
+  (backward-kill-sexp)
+  (condition-case nil
+      (prin1 (eval (read (current-kill 0)))
+             (current-buffer))
+    (error (message "Invalid expression")
+           (insert (current-kill 0)))))
+(global-set-key (kbd "C-c e") 'eval-and-replace)

--- a/trailing-whitespace.el
+++ b/trailing-whitespace.el
@@ -1,0 +1,16 @@
+(setq-default show-trailing-whitespace t)
+
+(defun disable-trailing-whitespace-display ()
+  (setq show-trailing-whitespace nil))
+
+;; Disable trailing whitespace display for special-mode children and
+;; some other modes as well. This includes stuff like the git log view
+;; mode and suchlike.
+(add-hook 'special-mode-hook 'disable-trailing-whitespace-display)
+(add-hook 'compilation-mode-hook 'disable-trailing-whitespace-display)
+(add-hook 'diff-mode-hook 'disable-trailing-whitespace-display)
+(add-hook 'term-mode-hook 'disable-trailing-whitespace-display)
+(add-hook 'shell-mode-hook 'disable-trailing-whitespace-display)
+
+(defun enable-autoclear-whitespace ()
+  (add-hook 'before-save-hook 'delete-trailing-whitespace nil t))

--- a/windows.el
+++ b/windows.el
@@ -1,0 +1,1 @@
+(prefer-coding-system 'utf-8)


### PR DESCRIPTION
This merge brings in a fairly extensive overhaul to the whole setup:
- Content is split into multiple files instead of keeping everything in a single init.el
- Melpa stable is replaced by the "basic" Melpa
- use-package is used instead of imperative configuration

Some parts were not yet a fully upgraded to use-package